### PR TITLE
changes for scrape, configs, etc

### DIFF
--- a/migrate-grok-ed/README.md
+++ b/migrate-grok-ed/README.md
@@ -2,8 +2,16 @@
 
 To convert a Grok project to Ed, you need to do the following:
 
+## Installation
 - Install all python modules (probably via `pip install poetry && poetry install`)
-- Install all the modules for amber-util (probably via `yarn install` in the amber-util directory)
+- Install all the modules for amber-util (probably via `yarn install` or `npm install` in the amber-util directory)
 - Fill in the necessary fields in config.ini
-- Run `poetry run python scrape_grok.py` to scrape the data from Grok, parse it, unpack it, and convert the Markdown to Amber (Ed's format for representing the content of a slide or 'challenge')
-- Run `poetry run python scrape_grok.py` to upload the scraped data to Ed
+
+
+## Run
+
+- Host the amber-util using a http server (probably use `npx http-server./` from the amber-util folder path)
+- Run `poetry run python scrape_grok.py` to scrape the data from Grok, 
+- Run `poetry run python arrange_files.py` parse it, unpack it.
+- Run `poetry run python preprocess_markdown.py` to convert the Markdown to Amber (Ed's format for representing the content of a slide or 'challenge')
+- Run `poetry run python upload.py` to upload the scraped data to Ed

--- a/migrate-grok-ed/arrange_files.py
+++ b/migrate-grok-ed/arrange_files.py
@@ -24,6 +24,7 @@ import json
 import shutil
 import pathlib
 from pathlib import Path
+from configparser import ConfigParser
 
 import os
 
@@ -44,6 +45,16 @@ logger = logging.getLogger(__name__)
 
 DRY_RUN = False
 DRY_RUN_STR = "[DRY RUN] " if DRY_RUN else ""
+config = ConfigParser()
+config.read("config/config_comp90059.ini")
+grok_slug = config.get("GROK", "grok_course_slug")
+log_dir =  Path("output")/ grok_slug / "logs"
+log_dir.mkdir(parents=True, exist_ok=True)
+file_handler = logging.FileHandler(filename=log_dir / "arrange_files.log")
+file_handler.formatter = logging.Formatter(
+    "%(asctime)s %(name)-12s %(levelname)-8s %(message)s", datefmt="%d-%b-%y %H:%M:%S"
+)
+logger.addHandler( file_handler)
 
 
 def main():
@@ -53,7 +64,7 @@ def main():
     # get the directory the executing file is in
     cwd = Path(os.path.dirname(os.path.realpath(__file__)))
     # get the path to the output/grok_exercises directory
-    output_base = cwd / "output" / "grok_exercises"
+    output_base = cwd / "output" / grok_slug / "grok_exercises"
     moved_files = 0
     # iterate through all the json files in output/grok_exercises and move them to a subdirectory based on the json key "title"
     logger.info(output_base)
@@ -70,7 +81,7 @@ def main():
         title = data["title"]
         slug = data["slug"]
         logging.debug(f"Obtained Slug and Title: {slug}, {title}")
-        if "unimelb-comp10001-2024-s2" not in slug:
+        if grok_slug not in slug:
             open("remainders.txt", "a").write(file_path + "\n")
             continue
 

--- a/migrate-grok-ed/config/config_busa90539.ini
+++ b/migrate-grok-ed/config/config_busa90539.ini
@@ -1,0 +1,25 @@
+[GLOBAL]
+
+# logging level can be one of CRITICAL, ERROR, WARNING, INFO, DEBUG
+log_level = INFO
+
+[GROK]
+# the grok session token, extracted from the cookies of a logged in user (note I have attempted to provide a Selenium-based startup-screen to grab this automatically if unset)
+grok_token = xxxxxxxx
+
+# the course slug used to identify the course in Grok
+grok_course_slug = unimelb-busa90539-2024-s1
+
+
+
+[ED]
+
+# Course id for EdStem
+ed_course_id = 20011
+
+# lesson programming type
+lesson_type = MySQL
+
+# edstem api token
+ed_token = xxxxxxx
+

--- a/migrate-grok-ed/config/config_comp10001.ini
+++ b/migrate-grok-ed/config/config_comp10001.ini
@@ -1,0 +1,29 @@
+[GLOBAL]
+
+# logging level can be one of CRITICAL, ERROR, WARNING, INFO, DEBUG
+log_level = INFO
+
+[GROK]
+# the grok session token, extracted from the cookies of a logged in user (note I have attempted to provide a Selenium-based startup-screen to grab this automatically if unset)
+grok_token = xxxxxx
+
+
+# the course slug used to identify the course in Grok
+grok_course_slug = unimelb-comp10001-2024-s2
+
+
+excluded_problems = 26311,26399,26410,26396,26382,26393,26397,26398,26401,26394,26400,26395,26309,26307,26306,26308,26304,26302,26303,26305,26310
+excluded_modules = exam,mst,project,unimelb-comp10001-2024-s2-p0-practice
+excluded_submodules = exam,mst,project,unimelb-comp10001-2024-s2-p0-practice
+
+
+[ED]
+
+# Course id for EdStem
+ed_course_id = 19991
+
+# lesson programming type
+lesson_type = python
+
+# edstem api token
+ed_token = xxxxxx

--- a/migrate-grok-ed/config/config_comp30020.ini
+++ b/migrate-grok-ed/config/config_comp30020.ini
@@ -1,0 +1,25 @@
+[GLOBAL]
+
+# logging level can be one of CRITICAL, ERROR, WARNING, INFO, DEBUG
+log_level = INFO
+
+[GROK]
+# the grok session token, extracted from the cookies of a logged in user (note I have attempted to provide a Selenium-based startup-screen to grab this automatically if unset)
+grok_token = xxxxx
+
+# the course slug used to identify the course in Grok
+grok_course_slug = unimelb-comp30020-2024-s2
+
+
+
+[ED]
+
+# Course id for EdStem
+ed_course_id =
+
+# lesson programming type
+lesson_type = python
+
+# edstem api token
+ed_token = xxxxx
+

--- a/migrate-grok-ed/config/config_comp90059.ini
+++ b/migrate-grok-ed/config/config_comp90059.ini
@@ -1,0 +1,25 @@
+[GLOBAL]
+
+# logging level can be one of CRITICAL, ERROR, WARNING, INFO, DEBUG
+log_level = INFO
+
+[GROK]
+# the grok session token, extracted from the cookies of a logged in user (note I have attempted to provide a Selenium-based startup-screen to grab this automatically if unset)
+grok_token = xxxxx
+
+# the course slug used to identify the course in Grok
+grok_course_slug = unimelb-comp90059-2024-s2
+
+
+
+[ED]
+
+# Course id for EdStem
+ed_course_id = 20021
+
+# lesson programming type
+lesson_type = python
+
+# edstem api token
+ed_token = xxxxx
+

--- a/migrate-grok-ed/pyproject.toml
+++ b/migrate-grok-ed/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["Shaanan Cohney <shaananc@gmail.com>"]
 readme = "README.md"
 
 [tool.poetry.dependencies]
-python = "^3.12"
+python = "^3.10"
 cachier = "^3.1.2"
 selenium = "^4.26.0"
 requests = "^2.32.3"


### PR DESCRIPTION
Changes done 

- different config files for different subjects. All cnfigs are in a folder named config.
- the output now creates a subfolder for each subject code
- There were some hardcoded module names/problem codes etc that are now moved to config
- the logs are now created for under each subject code subfolder
- there were issues in code for exporting problem that is now fixed
- Additional resources from grok-cdn is downloaded into the subject subfolder/resources. these includes images/txt or SQL files etc.
- the code blocks in slides titles are removed while uploading to Ed
- The lessons under a module was not created in order, this is now fixed.